### PR TITLE
base64-encode generates valid C++ files now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(base64-encoder LANGUAGES CXX C)
 set (CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+add_compile_options(-std=c++98)
+
 add_compile_options(-g)
 add_compile_options(-O0)
 

--- a/libb64/src/cencode.c
+++ b/libb64/src/cencode.c
@@ -75,7 +75,9 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			++(state_in->stepcount);
 			if (state_in->stepcount == CHARS_PER_LINE/4)
 			{
+                *codechar++ = '\"';
 				*codechar++ = '\n';
+                *codechar++ = '\"';
 				state_in->stepcount = 0;
 			}
 		}

--- a/main.cpp
+++ b/main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
 	
 	// open the output file in binary-mode
 	std::string output = argv[3];
-	std::ofstream outstream(output.c_str(), std::ios_base::out | std::ios_base::binary);
+	std::ofstream outstream(output.c_str(), std::ios_base::out);
 	if (!outstream.is_open())
 	{
 		usage(argv[0], "Could not open output file " + output);
@@ -88,12 +88,13 @@ int main(int argc, char** argv)
 	
 	std::streampos startPos = outstream.tellp();
 	base64::encoder E;
+
 	E.encode(instream, outstream);
 	outstream.seekp(-1, std::ios::cur); // rewind by 1 character to delete the '\n' written by libb64
 	std::streampos endPos = outstream.tellp();
-	size_t len = endPos - startPos;
+	// size_t len = endPos - startPos;
 	std::string footer = "\";\nextern unsigned int " + encodeFormatFileName
-                       + "_len = " + int_to_string(len) + ";\n";
+                       + "_len = sizeof(" + encodeFormatFileName + ");\n";
 
 	outstream.write(footer.data(),footer.length());
 


### PR DESCRIPTION
Fixed minor issues to ensure that it generates valid C++ source.